### PR TITLE
Use Direct I/O for segment merging to keep disk cache warm

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,11 @@
       <artifactId>lucene-spatial-extras</artifactId>
       <version>${lucene.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.lucene</groupId>
+      <artifactId>lucene-misc</artifactId>
+      <version>${lucene.version}</version>
+    </dependency>
 
     <!-- Dropwizard -->
     <dependency>

--- a/src/main/java/com/cloudant/nouveau/core/IndexManager.java
+++ b/src/main/java/com/cloudant/nouveau/core/IndexManager.java
@@ -47,6 +47,7 @@ import com.github.benmanes.caffeine.cache.Scheduler;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.misc.store.DirectIODirectory;
 import org.apache.lucene.search.SearcherFactory;
 import org.apache.lucene.search.SearcherManager;
 import org.apache.lucene.search.Sort;
@@ -464,7 +465,7 @@ public class IndexManager implements Managed {
     }
 
     private Directory directory(final Path path) throws IOException {
-        return FSDirectory.open(path);
+        return new DirectIODirectory(FSDirectory.open(path));
     }
 
 }


### PR DESCRIPTION
c.f https://lucene.apache.org/core/9_1_0/misc/index.html

"[DirectIODirectory](https://lucene.apache.org/core/9_1_0/misc/org/apache/lucene/misc/store/DirectIODirectory.html) is a Directory implementation that bypasses the OS's buffer cache (using direct IO) for any IndexInput and IndexOutput used during merging of segments larger than a specified size (default 10 MB). This avoids evicting hot pages that are still in-use for searching, keeping search more responsive while large merges run."
